### PR TITLE
Fix HUD Windows compatibility issues (Issue #138)

### DIFF
--- a/commands/hud.md
+++ b/commands/hud.md
@@ -78,6 +78,7 @@ Then, use the Write tool to create `~/.claude/hud/omc-hud.mjs` with this exact c
 import { existsSync, readdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 
 async function main() {
   const home = homedir();
@@ -89,11 +90,11 @@ async function main() {
     try {
       const versions = readdirSync(pluginCacheBase);
       if (versions.length > 0) {
-        const latestVersion = versions.sort().reverse()[0];
+        const latestVersion = versions.sort((a, b) => a.localeCompare(b, undefined, { numeric: true })).reverse()[0];
         pluginCacheDir = join(pluginCacheBase, latestVersion);
         const pluginPath = join(pluginCacheDir, "dist/hud/index.js");
         if (existsSync(pluginPath)) {
-          await import(pluginPath);
+          await import(pathToFileURL(pluginPath).href);
           return;
         }
       }
@@ -111,7 +112,7 @@ async function main() {
   for (const devPath of devPaths) {
     if (existsSync(devPath)) {
       try {
-        await import(devPath);
+        await import(pathToFileURL(devPath).href);
         return;
       } catch { /* continue */ }
     }
@@ -135,12 +136,24 @@ chmod +x ~/.claude/hud/omc-hud.mjs
 
 **Step 4:** Update settings.json to use the HUD:
 
-Read `~/.claude/settings.json`, then update/add the `statusLine` field:
+Read `~/.claude/settings.json`, then update/add the `statusLine` field.
+
+**macOS/Linux:**
 ```json
 {
   "statusLine": {
     "type": "command",
     "command": "node ~/.claude/hud/omc-hud.mjs"
+  }
+}
+```
+
+**Windows:** (Use `%USERPROFILE%` or absolute path - Node.js doesn't expand `~`)
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "node %USERPROFILE%\\.claude\\hud\\omc-hud.mjs"
   }
 }
 ```

--- a/scripts/session-start.mjs
+++ b/scripts/session-start.mjs
@@ -48,7 +48,7 @@ function countIncompleteTodos(todosDir) {
 
 // Check if HUD is properly installed
 function checkHudInstallation() {
-  const hudScript = join(homedir(), '.claude', 'hud', 'sisyphus-hud.mjs');
+  const hudScript = join(homedir(), '.claude', 'hud', 'omc-hud.mjs');
   const settingsFile = join(homedir(), '.claude', 'settings.json');
 
   // Check if HUD script exists

--- a/skills/hud/SKILL.md
+++ b/skills/hud/SKILL.md
@@ -81,6 +81,7 @@ Then, use the Write tool to create `~/.claude/hud/omc-hud.mjs` with this exact c
 import { existsSync, readdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 
 async function main() {
   const home = homedir();
@@ -92,11 +93,11 @@ async function main() {
     try {
       const versions = readdirSync(pluginCacheBase);
       if (versions.length > 0) {
-        const latestVersion = versions.sort().reverse()[0];
+        const latestVersion = versions.sort((a, b) => a.localeCompare(b, undefined, { numeric: true })).reverse()[0];
         pluginCacheDir = join(pluginCacheBase, latestVersion);
         const pluginPath = join(pluginCacheDir, "dist/hud/index.js");
         if (existsSync(pluginPath)) {
-          await import(pluginPath);
+          await import(pathToFileURL(pluginPath).href);
           return;
         }
       }
@@ -114,7 +115,7 @@ async function main() {
   for (const devPath of devPaths) {
     if (existsSync(devPath)) {
       try {
-        await import(devPath);
+        await import(pathToFileURL(devPath).href);
         return;
       } catch { /* continue */ }
     }
@@ -138,12 +139,24 @@ chmod +x ~/.claude/hud/omc-hud.mjs
 
 **Step 4:** Update settings.json to use the HUD:
 
-Read `~/.claude/settings.json`, then update/add the `statusLine` field:
+Read `~/.claude/settings.json`, then update/add the `statusLine` field.
+
+**macOS/Linux:**
 ```json
 {
   "statusLine": {
     "type": "command",
     "command": "node ~/.claude/hud/omc-hud.mjs"
+  }
+}
+```
+
+**Windows:** (Use `%USERPROFILE%` or absolute path - Node.js doesn't expand `~`)
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "node %USERPROFILE%\\.claude\\hud\\omc-hud.mjs"
   }
 }
 ```

--- a/src/__tests__/hud-windows.test.ts
+++ b/src/__tests__/hud-windows.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+
+/**
+ * HUD Windows Compatibility Tests
+ *
+ * These tests verify fixes for GitHub Issue #138:
+ * - Bug 1: File naming (sisyphus-hud.mjs → omc-hud.mjs)
+ * - Bug 2: Windows ~ expansion (documentation updates)
+ * - Bug 3: Windows dynamic import() requires file:// URLs
+ * - Bug 4: Version sorting (numeric vs lexicographic)
+ */
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const packageRoot = join(__dirname, '..', '..');
+
+describe('HUD Windows Compatibility (Issue #138)', () => {
+  describe('Bug 1: File Naming (Rebranding)', () => {
+    it('session-start.mjs should reference omc-hud.mjs, not sisyphus-hud.mjs', () => {
+      const sessionStartPath = join(packageRoot, 'scripts', 'session-start.mjs');
+      expect(existsSync(sessionStartPath)).toBe(true);
+
+      const content = readFileSync(sessionStartPath, 'utf-8');
+
+      // Should use the new name
+      expect(content).toContain('omc-hud.mjs');
+
+      // Should NOT use the old name
+      expect(content).not.toContain('sisyphus-hud.mjs');
+    });
+
+    it('installer should create omc-hud.mjs, not sisyphus-hud.mjs', () => {
+      const installerPath = join(packageRoot, 'src', 'installer', 'index.ts');
+      expect(existsSync(installerPath)).toBe(true);
+
+      const content = readFileSync(installerPath, 'utf-8');
+
+      // Should use the new name
+      expect(content).toContain('omc-hud.mjs');
+
+      // Should NOT use the old name
+      expect(content).not.toContain('sisyphus-hud.mjs');
+    });
+  });
+
+  describe('Bug 2: Windows ~ Path Expansion', () => {
+    it('hud.md should document Windows path syntax', () => {
+      const hudMdPath = join(packageRoot, 'commands', 'hud.md');
+      expect(existsSync(hudMdPath)).toBe(true);
+
+      const content = readFileSync(hudMdPath, 'utf-8');
+
+      // Should document Windows path
+      expect(content).toContain('%USERPROFILE%');
+
+      // Should explain the issue
+      expect(content).toMatch(/Windows.*Node\.js.*doesn.*expand.*~/i);
+    });
+
+    it('SKILL.md should document Windows path syntax', () => {
+      const skillMdPath = join(packageRoot, 'skills', 'hud', 'SKILL.md');
+      expect(existsSync(skillMdPath)).toBe(true);
+
+      const content = readFileSync(skillMdPath, 'utf-8');
+
+      // Should document Windows path
+      expect(content).toContain('%USERPROFILE%');
+
+      // Should explain the issue
+      expect(content).toMatch(/Windows.*Node\.js.*doesn.*expand.*~/i);
+    });
+
+    it('installer should use absolute paths for statusLine command', () => {
+      const installerPath = join(packageRoot, 'src', 'installer', 'index.ts');
+      const content = readFileSync(installerPath, 'utf-8');
+
+      // The installer constructs the path using join() which produces absolute paths
+      // It uses: command: 'node ' + hudScriptPath
+      expect(content).toContain("command: 'node ' + hudScriptPath");
+
+      // hudScriptPath is constructed with join(HUD_DIR, ...), not hardcoded with ~
+      expect(content).toContain("join(HUD_DIR, 'omc-hud.mjs')");
+    });
+  });
+
+  describe('Bug 3: Windows Dynamic Import Path', () => {
+    it('installer HUD script should use pathToFileURL for imports', () => {
+      const installerPath = join(packageRoot, 'src', 'installer', 'index.ts');
+      const content = readFileSync(installerPath, 'utf-8');
+
+      // Should import pathToFileURL
+      expect(content).toContain("pathToFileURL");
+
+      // Should use pathToFileURL for plugin path import
+      expect(content).toContain('pathToFileURL(pluginPath).href');
+
+      // Should use pathToFileURL for dev path import
+      expect(content).toContain('pathToFileURL(devPath).href');
+    });
+
+    it('hud.md embedded script should use pathToFileURL', () => {
+      const hudMdPath = join(packageRoot, 'commands', 'hud.md');
+      const content = readFileSync(hudMdPath, 'utf-8');
+
+      // Should import pathToFileURL
+      expect(content).toContain('import { pathToFileURL } from "node:url"');
+
+      // Should use pathToFileURL for imports
+      expect(content).toContain('pathToFileURL(pluginPath).href');
+      expect(content).toContain('pathToFileURL(devPath).href');
+    });
+
+    it('SKILL.md embedded script should use pathToFileURL', () => {
+      const skillMdPath = join(packageRoot, 'skills', 'hud', 'SKILL.md');
+      const content = readFileSync(skillMdPath, 'utf-8');
+
+      // Should import pathToFileURL
+      expect(content).toContain('import { pathToFileURL } from "node:url"');
+
+      // Should use pathToFileURL for imports
+      expect(content).toContain('pathToFileURL(pluginPath).href');
+      expect(content).toContain('pathToFileURL(devPath).href');
+    });
+
+    it('pathToFileURL should correctly convert paths', () => {
+      // Unix path
+      const unixPath = '/home/user/test.js';
+      expect(pathToFileURL(unixPath).href).toBe('file:///home/user/test.js');
+
+      // Path with spaces
+      const spacePath = '/path/with spaces/file.js';
+      expect(pathToFileURL(spacePath).href).toBe('file:///path/with%20spaces/file.js');
+    });
+  });
+
+  describe('Bug 4: Version Sorting', () => {
+    it('installer HUD script should use numeric version sorting', () => {
+      const installerPath = join(packageRoot, 'src', 'installer', 'index.ts');
+      const content = readFileSync(installerPath, 'utf-8');
+
+      // Should use localeCompare with numeric option
+      expect(content).toContain('localeCompare(b, undefined, { numeric: true })');
+    });
+
+    it('hud.md embedded script should use numeric version sorting', () => {
+      const hudMdPath = join(packageRoot, 'commands', 'hud.md');
+      const content = readFileSync(hudMdPath, 'utf-8');
+
+      // Should use localeCompare with numeric option
+      expect(content).toContain('localeCompare(b, undefined, { numeric: true })');
+
+      // Should NOT use simple sort().reverse()
+      // The old pattern was: versions.sort().reverse()[0]
+      expect(content).not.toMatch(/versions\.sort\(\)\.reverse\(\)/);
+    });
+
+    it('SKILL.md embedded script should use numeric version sorting', () => {
+      const skillMdPath = join(packageRoot, 'skills', 'hud', 'SKILL.md');
+      const content = readFileSync(skillMdPath, 'utf-8');
+
+      // Should use localeCompare with numeric option
+      expect(content).toContain('localeCompare(b, undefined, { numeric: true })');
+
+      // Should NOT use simple sort().reverse()
+      expect(content).not.toMatch(/versions\.sort\(\)\.reverse\(\)/);
+    });
+
+    it('numeric sort should correctly order versions', () => {
+      const versions = ['3.5.0', '3.10.0', '3.9.0'];
+
+      // Incorrect lexicographic sort
+      const lexSorted = [...versions].sort().reverse();
+      expect(lexSorted[0]).toBe('3.9.0'); // Wrong! 9 > 5 > 1 lexicographically
+
+      // Correct numeric sort
+      const numSorted = [...versions].sort((a, b) =>
+        a.localeCompare(b, undefined, { numeric: true })
+      ).reverse();
+      expect(numSorted[0]).toBe('3.10.0'); // Correct! 10 > 9 > 5 numerically
+    });
+
+    it('should handle edge cases in version sorting', () => {
+      // Single digit vs double digit
+      const versions1 = ['1.0.0', '10.0.0', '2.0.0', '9.0.0'];
+      const sorted1 = [...versions1].sort((a, b) =>
+        a.localeCompare(b, undefined, { numeric: true })
+      ).reverse();
+      expect(sorted1).toEqual(['10.0.0', '9.0.0', '2.0.0', '1.0.0']);
+
+      // Patch version comparison
+      const versions2 = ['1.0.1', '1.0.10', '1.0.9', '1.0.2'];
+      const sorted2 = [...versions2].sort((a, b) =>
+        a.localeCompare(b, undefined, { numeric: true })
+      ).reverse();
+      expect(sorted2).toEqual(['1.0.10', '1.0.9', '1.0.2', '1.0.1']);
+    });
+  });
+});

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -7,6 +7,7 @@
  */
 
 import { join } from 'path';
+import { pathToFileURL } from 'url';
 import { homedir } from 'os';
 
 /**
@@ -57,4 +58,54 @@ export function getConfigDir(): string {
     return process.env.APPDATA || join(homedir(), 'AppData', 'Roaming');
   }
   return process.env.XDG_CONFIG_HOME || join(homedir(), '.config');
+}
+
+/**
+ * Convert a file path to a file:// URL suitable for dynamic import()
+ *
+ * On Windows, dynamic import() requires file:// URLs instead of plain paths.
+ * This is because Windows paths like C:\path\to\file.js are not valid URLs.
+ *
+ * @param filePath - Absolute file path to convert
+ * @returns file:// URL string suitable for import()
+ *
+ * @example
+ * // Windows
+ * toImportUrl('C:\\Users\\test\\file.js')
+ * // => 'file:///C:/Users/test/file.js'
+ *
+ * // Unix
+ * toImportUrl('/home/user/file.js')
+ * // => 'file:///home/user/file.js'
+ *
+ * // Spaces are encoded
+ * toImportUrl('C:\\Program Files\\app\\file.js')
+ * // => 'file:///C:/Program%20Files/app/file.js'
+ */
+export function toImportUrl(filePath: string): string {
+  return pathToFileURL(filePath).href;
+}
+
+/**
+ * Sort version strings numerically (not lexicographically)
+ *
+ * Standard sort() treats version strings as text, so "3.10.0" < "3.9.0" because
+ * "1" < "9" in lexicographic order. This function uses numeric comparison.
+ *
+ * @param versions - Array of version strings to sort
+ * @param descending - Sort in descending order (default: true, latest first)
+ * @returns Sorted array of version strings
+ *
+ * @example
+ * sortVersions(['3.5.0', '3.10.0', '3.9.0'])
+ * // => ['3.10.0', '3.9.0', '3.5.0']
+ *
+ * sortVersions(['1.0.0', '2.0.0', '10.0.0'], false)
+ * // => ['1.0.0', '2.0.0', '10.0.0']
+ */
+export function sortVersions(versions: string[], descending: boolean = true): string[] {
+  const sorted = [...versions].sort((a, b) =>
+    a.localeCompare(b, undefined, { numeric: true })
+  );
+  return descending ? sorted.reverse() : sorted;
 }


### PR DESCRIPTION
## Summary

- **Bug 1**: Rename `sisyphus-hud.mjs` to `omc-hud.mjs` in `session-start.mjs` (rebranding)
- **Bug 2**: Add Windows path documentation (`%USERPROFILE%` instead of `~`)
- **Bug 3**: Use `pathToFileURL()` for dynamic `import()` on Windows
- **Bug 4**: Use numeric version sorting instead of lexicographic

## Changes

### New utilities in `src/utils/paths.ts`
- `toImportUrl()`: Convert file paths to `file://` URLs for dynamic import()
- `sortVersions()`: Sort version strings numerically (fixes `3.10.0` > `3.9.0`)

### Files modified
- `scripts/session-start.mjs` - Bug 1 fix
- `src/installer/index.ts` - Bug 3, 4 fixes
- `commands/hud.md` - Bug 2, 3, 4 fixes
- `skills/hud/SKILL.md` - Bug 2, 3, 4 fixes
- `src/utils/paths.ts` - New utilities
- `src/utils/__tests__/paths.test.ts` - New tests for utilities

### New test file
- `src/__tests__/hud-windows.test.ts` - 14 tests for Windows compatibility

## Test plan
- [x] All 879 tests pass
- [x] Build succeeds
- [ ] Manual testing on Windows (version sorting, dynamic import)

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)