### PR TITLE
fix(issue-143): Fix state path mismatch between shell scripts and TypeScript

### DIFF
--- a/scripts/keyword-detector.mjs
+++ b/scripts/keyword-detector.mjs
@@ -137,15 +137,15 @@ function activateUltraworkState(directory, prompt) {
     last_checked_at: new Date().toISOString()
   };
 
-  // Write to local .sisyphus directory
-  const localDir = join(directory, '.omc');
+  // Write to local .omc/state directory
+  const localDir = join(directory, '.omc', 'state');
   if (!existsSync(localDir)) {
     try { mkdirSync(localDir, { recursive: true }); } catch {}
   }
   try { writeFileSync(join(localDir, 'ultrawork-state.json'), JSON.stringify(state, null, 2)); } catch {}
 
-  // Write to global .claude directory
-  const globalDir = join(homedir(), '.claude');
+  // Write to global .omc/state directory
+  const globalDir = join(homedir(), '.omc', 'state');
   if (!existsSync(globalDir)) {
     try { mkdirSync(globalDir, { recursive: true }); } catch {}
   }

--- a/scripts/persistent-mode.mjs
+++ b/scripts/persistent-mode.mjs
@@ -166,14 +166,14 @@ async function main() {
     const todosDir = join(homedir(), '.claude', 'todos');
 
     // Check for ultrawork state
-    let ultraworkState = readJsonFile(join(directory, '.omc', 'ultrawork-state.json'))
-      || readJsonFile(join(homedir(), '.claude', 'ultrawork-state.json'));
+    let ultraworkState = readJsonFile(join(directory, '.omc', 'state', 'ultrawork-state.json'))
+      || readJsonFile(join(homedir(), '.omc', 'state', 'ultrawork-state.json'));
 
     // Check for ralph loop state
-    const ralphState = readJsonFile(join(directory, '.omc', 'ralph-state.json'));
+    const ralphState = readJsonFile(join(directory, '.omc', 'state', 'ralph-state.json'));
 
     // Check for verification state
-    const verificationState = readJsonFile(join(directory, '.omc', 'ralph-verification.json'));
+    const verificationState = readJsonFile(join(directory, '.omc', 'state', 'ralph-verification.json'));
 
     // Count incomplete todos
     const incompleteCount = countIncompleteTodos(todosDir, directory);
@@ -256,7 +256,7 @@ ${verificationState.oracle_feedback}
       if (iteration < maxIter) {
         const newIter = iteration + 1;
         ralphState.iteration = newIter;
-        writeJsonFile(join(directory, '.omc', 'ralph-state.json'), ralphState);
+        writeJsonFile(join(directory, '.omc', 'state', 'ralph-state.json'), ralphState);
 
         // Build continuation message with PRD context if available
         let prdContext = '';
@@ -349,7 +349,7 @@ ${ralphState.prompt ? `Original task: ${ralphState.prompt}` : ''}
       ultraworkState.reinforcement_count = newCount;
       ultraworkState.last_checked_at = new Date().toISOString();
 
-      writeJsonFile(join(directory, '.omc', 'ultrawork-state.json'), ultraworkState);
+      writeJsonFile(join(directory, '.omc', 'state', 'ultrawork-state.json'), ultraworkState);
 
       console.log(JSON.stringify({
         continue: false,

--- a/scripts/persistent-mode.sh
+++ b/scripts/persistent-mode.sh
@@ -21,22 +21,22 @@ fi
 
 # Check for active ultrawork state
 ULTRAWORK_STATE=""
-if [ -f "$DIRECTORY/.omc/ultrawork-state.json" ]; then
-  ULTRAWORK_STATE=$(cat "$DIRECTORY/.omc/ultrawork-state.json" 2>/dev/null)
-elif [ -f "$HOME/.claude/ultrawork-state.json" ]; then
-  ULTRAWORK_STATE=$(cat "$HOME/.claude/ultrawork-state.json" 2>/dev/null)
+if [ -f "$DIRECTORY/.omc/state/ultrawork-state.json" ]; then
+  ULTRAWORK_STATE=$(cat "$DIRECTORY/.omc/state/ultrawork-state.json" 2>/dev/null)
+elif [ -f "$HOME/.omc/state/ultrawork-state.json" ]; then
+  ULTRAWORK_STATE=$(cat "$HOME/.omc/state/ultrawork-state.json" 2>/dev/null)
 fi
 
 # Check for active ralph loop
 RALPH_STATE=""
-if [ -f "$DIRECTORY/.omc/ralph-state.json" ]; then
-  RALPH_STATE=$(cat "$DIRECTORY/.omc/ralph-state.json" 2>/dev/null)
+if [ -f "$DIRECTORY/.omc/state/ralph-state.json" ]; then
+  RALPH_STATE=$(cat "$DIRECTORY/.omc/state/ralph-state.json" 2>/dev/null)
 fi
 
 # Check for verification state (oracle verification)
 VERIFICATION_STATE=""
-if [ -f "$DIRECTORY/.omc/ralph-verification.json" ]; then
-  VERIFICATION_STATE=$(cat "$DIRECTORY/.omc/ralph-verification.json" 2>/dev/null)
+if [ -f "$DIRECTORY/.omc/state/ralph-verification.json" ]; then
+  VERIFICATION_STATE=$(cat "$DIRECTORY/.omc/state/ralph-verification.json" 2>/dev/null)
 fi
 
 # Check for incomplete todos
@@ -106,7 +106,7 @@ EOF
     if [ "$ITERATION" -lt "$MAX_ITER" ]; then
       # Increment iteration
       NEW_ITER=$((ITERATION + 1))
-      echo "$RALPH_STATE" | jq ".iteration = $NEW_ITER" > "$DIRECTORY/.omc/ralph-state.json" 2>/dev/null
+      echo "$RALPH_STATE" | jq ".iteration = $NEW_ITER" > "$DIRECTORY/.omc/state/ralph-state.json" 2>/dev/null
 
       # Check if ultrawork is linked (auto-activated with ralph)
       LINKED_ULTRAWORK=$(echo "$RALPH_STATE" | jq -r '.linked_ultrawork // false' 2>/dev/null)
@@ -288,7 +288,7 @@ if [ -n "$ULTRAWORK_STATE" ] && [ "$INCOMPLETE_COUNT" -gt 0 ]; then
 
     # Update state file (best effort)
     if command -v jq &> /dev/null; then
-      echo "$ULTRAWORK_STATE" | jq ".reinforcement_count = $NEW_COUNT | .last_checked_at = \"$(date -Iseconds)\"" > "$DIRECTORY/.omc/ultrawork-state.json" 2>/dev/null
+      echo "$ULTRAWORK_STATE" | jq ".reinforcement_count = $NEW_COUNT | .last_checked_at = \"$(date -Iseconds)\"" > "$DIRECTORY/.omc/state/ultrawork-state.json" 2>/dev/null
     fi
 
     cat << EOF

--- a/scripts/session-start.mjs
+++ b/scripts/session-start.mjs
@@ -92,8 +92,8 @@ async function main() {
     }
 
     // Check for ultrawork state
-    const ultraworkState = readJsonFile(join(directory, '.omc', 'ultrawork-state.json'))
-      || readJsonFile(join(homedir(), '.claude', 'ultrawork-state.json'));
+    const ultraworkState = readJsonFile(join(directory, '.omc', 'state', 'ultrawork-state.json'))
+      || readJsonFile(join(homedir(), '.omc', 'state', 'ultrawork-state.json'));
 
     if (ultraworkState?.active) {
       messages.push(`<session-restore>
@@ -112,7 +112,7 @@ Continue working in ultrawork mode until all tasks are complete.
     }
 
     // Check for ralph loop state
-    const ralphState = readJsonFile(join(directory, '.omc', 'ralph-state.json'));
+    const ralphState = readJsonFile(join(directory, '.omc', 'state', 'ralph-state.json'));
     if (ralphState?.active) {
       messages.push(`<session-restore>
 


### PR DESCRIPTION
## Summary
- Shell scripts and Node.js scripts now use consistent `.omc/state/` paths for state files
- Matches the TypeScript state-manager standard defined in `src/features/state-manager/index.ts`
- Fixes silent session restore failures caused by path mismatch

## Changes
| File | Changes |
|------|---------|
| `scripts/persistent-mode.sh` | 10 path updates |
| `scripts/persistent-mode.mjs` | 6 path updates |
| `scripts/session-start.mjs` | 3 path updates |
| `scripts/keyword-detector.mjs` | 4 path updates |

## Path Standard
- **Local state:** `.omc/state/{name}.json`
- **Global state:** `~/.omc/state/{name}.json`

## Test Results
- All 1363 tests passing
- Grep verification: No incorrect paths remaining

Fixes #143

Generated with Claude Code