### PR TITLE
fix(rate-limit-wait): add ESM compatibility for __filename in daemon (#169)

### DIFF
--- a/src/features/rate-limit-wait/daemon.ts
+++ b/src/features/rate-limit-wait/daemon.ts
@@ -14,6 +14,7 @@
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync, unlinkSync, chmodSync, statSync } from 'fs';
 import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
 import { homedir } from 'os';
 import { spawn, spawnSync } from 'child_process';
 import { checkRateLimitStatus, formatRateLimitStatus, formatTimeUntilReset } from './rate-limit-monitor.js';
@@ -29,6 +30,9 @@ import type {
   BlockedPane,
   DaemonResponse,
 } from './types.js';
+
+// ESM compatibility: __filename is not available in ES modules
+const __filename = fileURLToPath(import.meta.url);
 
 /** Default configuration */
 const DEFAULT_CONFIG: Required<DaemonConfig> = {


### PR DESCRIPTION
## Summary

- Add ESM-compatible `__filename` definition to `daemon.ts`
- Fix `ReferenceError: __filename is not defined` when running `omc wait --start`

## Problem

When running `omc wait --start`, the daemon would fail with:
```
ReferenceError: __filename is not defined
```

This occurred because `daemon.ts` was using `__filename` directly (line 421), which is only available in CommonJS modules. Since the project uses ES modules (`"type": "module"` in package.json), this variable is not defined.

## Solution

Added the standard ESM-compatible pattern used throughout the codebase:
```typescript
import { fileURLToPath } from 'url';
const __filename = fileURLToPath(import.meta.url);
```

## Testing

- [x] `npm run build` - passes
- [x] `npm run test:run` - daemon tests pass (65/65)
- [x] `omc wait --start` - works without error
- [x] `omc wait status` - shows daemon running
- [x] `omc wait --stop` - stops daemon correctly

## Related

Fixes Yeachan-Heo/oh-my-claudecode#169

🤖 Generated with [Claude Code](https://claude.ai/code)