### PR TITLE
refactor(hud): extract indicator helper functions to reduce duplication

### DIFF
--- a/src/__tests__/hud/analytics-display.test.ts
+++ b/src/__tests__/hud/analytics-display.test.ts
@@ -185,6 +185,13 @@ describe('renderAnalyticsLineWithConfig', () => {
       expect(parts).toHaveLength(2);
     });
   });
+
+  describe('edge cases', () => {
+    it('handles empty topAgents gracefully', () => {
+      const result = renderAnalyticsLineWithConfig({ ...baseAnalytics, topAgents: 'none' }, true, true);
+      expect(result).toContain('Top: none');
+    });
+  });
 });
 
 describe('getSessionHealthAnalyticsData', () => {

--- a/src/hud/analytics-display.ts
+++ b/src/hud/analytics-display.ts
@@ -101,12 +101,33 @@ function formatTokenCount(tokens: number): string {
 }
 
 /**
+ * Get cost color indicator emoji based on cost color.
+ */
+function getCostColorIndicator(color: 'green' | 'yellow' | 'red'): string {
+  switch (color) {
+    case 'green': return '🟢';
+    case 'yellow': return '🟡';
+    case 'red': return '🔴';
+  }
+}
+
+/**
+ * Get health indicator emoji based on session health status.
+ */
+function getHealthIndicator(health: 'healthy' | 'warning' | 'critical'): string {
+  switch (health) {
+    case 'healthy': return '🟢';
+    case 'warning': return '🟡';
+    case 'critical': return '🔴';
+  }
+}
+
+/**
  * Render analytics as a single-line string for HUD display.
- * @deprecated Use renderSessionHealthAnalytics instead
+ * @deprecated Use renderAnalyticsLineWithConfig() for config-aware rendering
  */
 export function renderAnalyticsLine(analytics: AnalyticsDisplay): string {
-  const costIndicator = analytics.costColor === 'green' ? '🟢' :
-                        analytics.costColor === 'yellow' ? '🟡' : '🔴';
+  const costIndicator = getCostColorIndicator(analytics.costColor);
 
   return `${costIndicator} Cost: ${analytics.sessionCost} | Tokens: ${analytics.sessionTokens} | Cache: ${analytics.cacheEfficiency} | Top: ${analytics.topAgents}`;
 }
@@ -122,8 +143,7 @@ export function renderAnalyticsLineWithConfig(
   const parts: string[] = [];
 
   if (showCost) {
-    const costIndicator = analytics.costColor === 'green' ? '🟢' :
-                          analytics.costColor === 'yellow' ? '🟡' : '🔴';
+    const costIndicator = getCostColorIndicator(analytics.costColor);
     parts.push(`${costIndicator} Cost: ${analytics.sessionCost}`);
   }
 
@@ -165,8 +185,7 @@ export async function getSessionInfo(): Promise<string> {
  * Extract structured analytics data from SessionHealth
  */
 export function getSessionHealthAnalyticsData(sessionHealth: SessionHealth): SessionHealthAnalyticsData {
-  const costIndicator = sessionHealth.health === 'critical' ? '🔴' :
-                        sessionHealth.health === 'warning' ? '🟡' : '🟢';
+  const costIndicator = getHealthIndicator(sessionHealth.health);
 
   const costPrefix = sessionHealth.isEstimated ? '~' : '';
   const cost = `${costPrefix}$${(sessionHealth.sessionCost ?? 0).toFixed(4)}`;


### PR DESCRIPTION
## Summary
- Add `getCostColorIndicator()` helper for cost color to emoji mapping
- Add `getHealthIndicator()` helper for session health to emoji mapping
- Replace 3 duplicated ternary expressions with helper function calls
- Fix incorrect deprecation comment on `renderAnalyticsLine()` (now points to `renderAnalyticsLineWithConfig()`)
- Add edge case test for empty topAgents (`'none'`) handling

## Context
This PR implements and validates the changes proposed in [PR #164](https://github.com/Yeachan-Heo/oh-my-claudecode/pull/164) from the upstream fork.

## Test plan
- [x] `npm run build` passes - no TypeScript errors
- [x] `npm test` passes - all 32 analytics-display tests pass including new edge case test
- [x] Helper functions correctly map all enum values
- [x] No regression in existing functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)