### PR TITLE
docs(hud): add showCache and showCost to config example

### DIFF
--- a/commands/hud.md
+++ b/commands/hud.md
@@ -257,7 +257,9 @@ You can manually edit the config file:
     "contextBar": true,
     "agents": true,
     "backgroundTasks": true,
-    "todos": true
+    "todos": true,
+    "showCache": true,
+    "showCost": true
   },
   "thresholds": {
     "contextWarning": 70,

--- a/skills/hud/SKILL.md
+++ b/skills/hud/SKILL.md
@@ -260,7 +260,9 @@ You can manually edit the config file:
     "contextBar": true,
     "agents": true,
     "backgroundTasks": true,
-    "todos": true
+    "todos": true,
+    "showCache": true,
+    "showCost": true
   },
   "thresholds": {
     "contextWarning": 70,


### PR DESCRIPTION
## Summary

Add missing `showCache` and `showCost` options to the manual configuration JSON example in HUD documentation.

## Problem

PR #133 added `showCache` and `showCost` configuration options to the HUD, but the documentation examples were not updated to include these options. This makes it difficult for users to discover these useful configuration flags.

## Verification

Confirmed that `showCache` and `showCost` are actively used in the codebase:
- `src/hud/types.ts:250-251` - Interface definition
- `src/hud/render.ts:43,51` - Rendering logic
- `src/hud/analytics-display.ts:140-141` - Analytics display

## Changes

- `commands/hud.md`: Add `showCache` and `showCost` to elements example
- `skills/hud/SKILL.md`: Add `showCache` and `showCost` to elements example

## Test Plan

- [x] JSON syntax is valid
- [x] Options match what was added in PR #133
- [x] Verified options are used in codebase

---
🤖 Generated with Claude Code