### PR TITLE
verify: PR #227 backward-compatible skill parser

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "oh-my-claudecode",
       "description": "Claude Code native multi-agent orchestration with intelligent model routing, 28 agent variants, and 30 powerful skills. Zero learning curve. Maximum power.",
-      "version": "3.8.12",
+      "version": "3.8.14",
       "author": {
         "name": "Yeachan Heo",
         "email": "hurrc04@gmail.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-claudecode",
-  "version": "3.8.13",
+  "version": "3.8.14",
   "description": "Multi-agent orchestration system for Claude Code",
   "author": {
     "name": "oh-my-claudecode contributors"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.8.14] - 2026-01-30
+
+### Added
+
+- **Bun Package Manager Support** (PR #219) - OMC setup now prefers Bun over npm when available, with automatic fallback. Includes duplicate cleanup logic and per-manager verification.
+- **MCP Skill Loading Tools** (PR #225) - Three new MCP tools (`load_omc_skills_local`, `load_omc_skills_global`, `list_omc_skills`) with 5-layer security hardening: path validation, symlink boundary checks, depth limits, content sanitization, and relative path output.
+
+### Fixed
+
+- **HUD OAuth Token Refresh** (PR #206) - Expired OAuth tokens now auto-refresh using RFC 6749 compliant refresh token grant, restoring rate limit display. Credentials persisted with atomic writes and 0o600 permissions.
+
+---
+
 ## [3.8.10] - 2026-01-30
 
 ### Deprecated

--- a/commands/omc-setup.md
+++ b/commands/omc-setup.md
@@ -130,7 +130,16 @@ if [ -d "$PLUGIN_DIR" ]; then
     # Check if dist/hud/index.js exists
     if [ ! -f "$PLUGIN_DIR/$PLUGIN_VERSION/dist/hud/index.js" ]; then
       echo "Plugin not built - building now..."
-      cd "$PLUGIN_DIR/$PLUGIN_VERSION" && npm install
+      cd "$PLUGIN_DIR/$PLUGIN_VERSION"
+      # Use bun (preferred) or npm for building
+      if command -v bun &> /dev/null; then
+        bun install
+      elif command -v npm &> /dev/null; then
+        npm install
+      else
+        echo "ERROR: Neither bun nor npm found. Please install Node.js or Bun first."
+        exit 1
+      fi
       if [ -f "dist/hud/index.js" ]; then
         echo "Build successful - HUD is ready"
       else
@@ -165,6 +174,11 @@ Ask user: "Would you like to install the OMC CLI for standalone analytics? (Reco
 # Check for bun (preferred) or npm
 if command -v bun &> /dev/null; then
   echo "Installing OMC CLI via bun..."
+  # Clean up npm version if it exists to avoid duplicates
+  if command -v npm &> /dev/null && npm list -g oh-my-claude-sisyphus &>/dev/null; then
+    echo "Removing existing npm installation to avoid duplicates..."
+    npm uninstall -g oh-my-claude-sisyphus 2>/dev/null
+  fi
   bun install -g oh-my-claude-sisyphus
 elif command -v npm &> /dev/null; then
   echo "Installing OMC CLI via npm..."
@@ -186,7 +200,7 @@ fi
 
 ### If User Chooses NO:
 
-Skip this step. User can install later with `npm install -g oh-my-claude-sisyphus`.
+Skip this step. User can install later with `bun install -g oh-my-claude-sisyphus` or `npm install -g oh-my-claude-sisyphus`.
 
 ## Step 4: Verify Plugin Installation
 
@@ -207,20 +221,42 @@ Ask user: "Would you like to install AST tools for advanced code search? (Patter
 ### If User Chooses YES:
 
 ```bash
-# Check for npm
-if command -v npm &> /dev/null; then
-  echo "Installing @ast-grep/napi..."
+# Check for bun (preferred) or npm
+if command -v bun &> /dev/null; then
+  PKG_MANAGER="bun"
+  echo "Installing @ast-grep/napi via bun..."
+  # Clean up npm version if it exists to avoid duplicates
+  if command -v npm &> /dev/null && npm list -g @ast-grep/napi &>/dev/null; then
+    echo "Removing existing npm installation to avoid duplicates..."
+    npm uninstall -g @ast-grep/napi 2>/dev/null
+  fi
+  bun install -g @ast-grep/napi
+elif command -v npm &> /dev/null; then
+  PKG_MANAGER="npm"
+  echo "Installing @ast-grep/napi via npm..."
   npm install -g @ast-grep/napi
+else
+  echo "ERROR: Neither bun nor npm found. Please install Node.js or Bun first."
+  exit 1
+fi
+
+# Verify installation
+if [ "$PKG_MANAGER" = "bun" ]; then
+  if bun pm ls -g 2>/dev/null | grep -q "@ast-grep/napi"; then
+    echo "✓ AST tools installed successfully via bun!"
+    echo "  Available tools: ast_grep_search, ast_grep_replace"
+    echo "  Supports: JavaScript, TypeScript, Python, Go, Rust, Java, and 11 more languages"
+  else
+    echo "⚠ Installation may have failed. You can install later with: bun install -g @ast-grep/napi"
+  fi
+else
   if npm list -g @ast-grep/napi &>/dev/null; then
-    echo "✓ AST tools installed successfully!"
+    echo "✓ AST tools installed successfully via npm!"
     echo "  Available tools: ast_grep_search, ast_grep_replace"
     echo "  Supports: JavaScript, TypeScript, Python, Go, Rust, Java, and 11 more languages"
   else
     echo "⚠ Installation may have failed. You can install later with: npm install -g @ast-grep/napi"
   fi
-else
-  echo "ERROR: npm not found. Please install Node.js first."
-  echo "You can install later with: npm install -g @ast-grep/napi"
 fi
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-claude-sisyphus",
-  "version": "3.8.13",
+  "version": "3.8.14",
   "description": "Multi-agent orchestration system for Claude Code - Inspired by oh-my-opencode",
   "type": "module",
   "main": "dist/index.js",

--- a/src/__tests__/hooks/learner/parser.test.ts
+++ b/src/__tests__/hooks/learner/parser.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Tests for Skill Parser
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseSkillFile } from '../../../hooks/learner/parser.js';
+
+describe('parseSkillFile', () => {
+  describe('backward compatibility', () => {
+    it('should parse skill with only name, description, and triggers (no id, no source)', () => {
+      const content = `---
+name: DateTime Helper
+description: Help with date and time operations
+triggers:
+  - datetime
+  - time
+  - date
+---
+
+This skill helps with date and time operations.`;
+
+      const result = parseSkillFile(content);
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toEqual([]);
+      expect(result.metadata.name).toBe('DateTime Helper');
+      expect(result.metadata.description).toBe('Help with date and time operations');
+      expect(result.metadata.triggers).toEqual(['datetime', 'time', 'date']);
+      expect(result.metadata.id).toBe('datetime-helper');
+      expect(result.metadata.source).toBe('manual');
+      expect(result.content).toBe('This skill helps with date and time operations.');
+    });
+
+    it('should derive id correctly from name with special characters', () => {
+      const content = `---
+name: "API/REST Helper!"
+description: Help with REST APIs
+triggers:
+  - api
+---
+
+Content here.`;
+
+      const result = parseSkillFile(content);
+
+      expect(result.valid).toBe(true);
+      expect(result.metadata.id).toBe('apirest-helper');
+      expect(result.metadata.name).toBe('API/REST Helper!');
+    });
+
+    it('should derive id correctly from name with multiple spaces', () => {
+      const content = `---
+name: "My   Super   Skill"
+description: A super skill
+triggers:
+  - super
+---
+
+Content.`;
+
+      const result = parseSkillFile(content);
+
+      expect(result.valid).toBe(true);
+      expect(result.metadata.id).toBe('my-super-skill');
+    });
+
+    it('should default source to manual when missing', () => {
+      const content = `---
+name: Test Skill
+description: Test description
+triggers:
+  - test
+---
+
+Content.`;
+
+      const result = parseSkillFile(content);
+
+      expect(result.valid).toBe(true);
+      expect(result.metadata.source).toBe('manual');
+    });
+
+    it('should work correctly with all fields including explicit id and source', () => {
+      const content = `---
+id: custom-id
+name: Complete Skill
+description: A complete skill
+source: extracted
+createdAt: "2024-01-01T00:00:00Z"
+sessionId: session-123
+quality: 5
+usageCount: 10
+triggers:
+  - complete
+  - full
+tags:
+  - tag1
+  - tag2
+---
+
+Full skill content.`;
+
+      const result = parseSkillFile(content);
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toEqual([]);
+      expect(result.metadata.id).toBe('custom-id');
+      expect(result.metadata.name).toBe('Complete Skill');
+      expect(result.metadata.description).toBe('A complete skill');
+      expect(result.metadata.source).toBe('extracted');
+      expect(result.metadata.createdAt).toBe('2024-01-01T00:00:00Z');
+      expect(result.metadata.sessionId).toBe('session-123');
+      expect(result.metadata.quality).toBe(5);
+      expect(result.metadata.usageCount).toBe(10);
+      expect(result.metadata.triggers).toEqual(['complete', 'full']);
+      expect(result.metadata.tags).toEqual(['tag1', 'tag2']);
+      expect(result.content).toBe('Full skill content.');
+    });
+
+    it('should fail validation when name is missing', () => {
+      const content = `---
+description: Missing name
+triggers:
+  - test
+---
+
+Content.`;
+
+      const result = parseSkillFile(content);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('Missing required field: name');
+    });
+
+    it('should fail validation when description is missing', () => {
+      const content = `---
+name: Test Skill
+triggers:
+  - test
+---
+
+Content.`;
+
+      const result = parseSkillFile(content);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('Missing required field: description');
+    });
+
+    it('should fail validation when triggers is missing', () => {
+      const content = `---
+name: Test Skill
+description: Test description
+---
+
+Content.`;
+
+      const result = parseSkillFile(content);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('Missing required field: triggers');
+    });
+
+    it('should fail validation when triggers is empty array', () => {
+      const content = `---
+name: Test Skill
+description: Test description
+triggers: []
+---
+
+Content.`;
+
+      const result = parseSkillFile(content);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('Missing required field: triggers');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle inline triggers array', () => {
+      const content = `---
+name: Inline Triggers
+description: Test inline array
+triggers: ["trigger1", "trigger2", "trigger3"]
+---
+
+Content.`;
+
+      const result = parseSkillFile(content);
+
+      expect(result.valid).toBe(true);
+      expect(result.metadata.triggers).toEqual(['trigger1', 'trigger2', 'trigger3']);
+    });
+
+    it('should handle quoted name and description', () => {
+      const content = `---
+name: "Quoted Name"
+description: "Quoted Description"
+triggers:
+  - test
+---
+
+Content.`;
+
+      const result = parseSkillFile(content);
+
+      expect(result.valid).toBe(true);
+      expect(result.metadata.name).toBe('Quoted Name');
+      expect(result.metadata.description).toBe('Quoted Description');
+    });
+
+    it('should handle single-quoted values', () => {
+      const content = `---
+name: 'Single Quoted'
+description: 'Also single quoted'
+triggers:
+  - 'trigger'
+---
+
+Content.`;
+
+      const result = parseSkillFile(content);
+
+      expect(result.valid).toBe(true);
+      expect(result.metadata.name).toBe('Single Quoted');
+      expect(result.metadata.description).toBe('Also single quoted');
+      expect(result.metadata.triggers).toEqual(['trigger']);
+    });
+
+    it('should fail when frontmatter is missing', () => {
+      const content = `Just plain content without frontmatter.`;
+
+      const result = parseSkillFile(content);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('Missing YAML frontmatter');
+    });
+  });
+});

--- a/src/__tests__/mnemosyne/parser.test.ts
+++ b/src/__tests__/mnemosyne/parser.test.ts
@@ -41,7 +41,7 @@ Content without required fields.
     const result = parseSkillFile(content);
 
     expect(result.valid).toBe(false);
-    expect(result.errors).toContain('Missing required field: id');
+    expect(result.errors).toContain('Missing required field: description');
     expect(result.errors).toContain('Missing required field: triggers');
   });
 

--- a/src/__tests__/omc-tools-server.test.ts
+++ b/src/__tests__/omc-tools-server.test.ts
@@ -3,8 +3,8 @@ import { omcToolsServer, omcToolNames, getOmcToolNames } from '../mcp/omc-tools-
 
 describe('omc-tools-server', () => {
   describe('omcToolNames', () => {
-    it('should export 15 tools total', () => {
-      expect(omcToolNames).toHaveLength(15);
+    it('should export 18 tools total', () => {
+      expect(omcToolNames).toHaveLength(18);
     });
 
     it('should have 12 LSP tools', () => {
@@ -31,25 +31,36 @@ describe('omc-tools-server', () => {
   describe('getOmcToolNames', () => {
     it('should return all tools by default', () => {
       const tools = getOmcToolNames();
-      expect(tools).toHaveLength(15);
+      expect(tools).toHaveLength(18);
     });
 
     it('should filter out LSP tools when includeLsp is false', () => {
       const tools = getOmcToolNames({ includeLsp: false });
       expect(tools.some(t => t.includes('lsp_'))).toBe(false);
-      expect(tools).toHaveLength(3); // 2 AST + 1 python
+      expect(tools).toHaveLength(6); // 2 AST + 1 python + 3 skills
     });
 
     it('should filter out AST tools when includeAst is false', () => {
       const tools = getOmcToolNames({ includeAst: false });
       expect(tools.some(t => t.includes('ast_'))).toBe(false);
-      expect(tools).toHaveLength(13); // 12 LSP + 1 python
+      expect(tools).toHaveLength(16); // 12 LSP + 1 python + 3 skills
     });
 
     it('should filter out python_repl when includePython is false', () => {
       const tools = getOmcToolNames({ includePython: false });
       expect(tools.some(t => t.includes('python_repl'))).toBe(false);
-      expect(tools).toHaveLength(14); // 12 LSP + 2 AST
+      expect(tools).toHaveLength(17); // 12 LSP + 2 AST + 3 skills
+    });
+
+    it('should filter out skills tools', () => {
+      const names = getOmcToolNames({ includeSkills: false });
+      expect(names).toHaveLength(15);
+      expect(names.every(n => !n.includes('load_omc_skills') && !n.includes('list_omc_skills'))).toBe(true);
+    });
+
+    it('should have 3 skills tools', () => {
+      const skillsTools = omcToolNames.filter(n => n.includes('load_omc_skills') || n.includes('list_omc_skills'));
+      expect(skillsTools).toHaveLength(3);
     });
   });
 

--- a/src/__tests__/tools/skills-tools.test.ts
+++ b/src/__tests__/tools/skills-tools.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { loadLocalTool, loadGlobalTool, listSkillsTool } from '../../tools/skills-tools.js';
+
+describe('skills-tools', () => {
+  describe('loadLocalTool', () => {
+    it('should have correct name and description', () => {
+      expect(loadLocalTool.name).toBe('load_omc_skills_local');
+      expect(loadLocalTool.description).toContain('project-local');
+    });
+
+    it('should return content array from handler', async () => {
+      const result = await loadLocalTool.handler({});
+      expect(result.content).toBeDefined();
+      expect(Array.isArray(result.content)).toBe(true);
+      expect(result.content[0].type).toBe('text');
+      expect(typeof result.content[0].text).toBe('string');
+    });
+
+    it('should reject path traversal in projectRoot', async () => {
+      await expect(loadLocalTool.handler({ projectRoot: '../../etc' }))
+        .rejects.toThrow('path traversal');
+    });
+
+    it('should reject absolute paths outside allowed dirs', async () => {
+      await expect(loadLocalTool.handler({ projectRoot: '/etc' }))
+        .rejects.toThrow('outside allowed directories');
+    });
+
+    it('should not expose absolute home paths in output', async () => {
+      const result = await loadLocalTool.handler({});
+      const text = result.content[0].text;
+      // Output should use relativePath, not absolute paths
+      expect(text).not.toMatch(/\/home\/[^/]+\//);
+    });
+  });
+
+  describe('loadGlobalTool', () => {
+    it('should have correct name and description', () => {
+      expect(loadGlobalTool.name).toBe('load_omc_skills_global');
+      expect(loadGlobalTool.description).toContain('global');
+    });
+
+    it('should return content array from handler', async () => {
+      const result = await loadGlobalTool.handler({} as Record<string, never>);
+      expect(result.content).toBeDefined();
+      expect(Array.isArray(result.content)).toBe(true);
+      expect(result.content[0].type).toBe('text');
+    });
+  });
+
+  describe('listSkillsTool', () => {
+    it('should have correct name and description', () => {
+      expect(listSkillsTool.name).toBe('list_omc_skills');
+      expect(listSkillsTool.description).toContain('all available');
+    });
+
+    it('should return content array from handler', async () => {
+      const result = await listSkillsTool.handler({});
+      expect(result.content).toBeDefined();
+      expect(Array.isArray(result.content)).toBe(true);
+    });
+
+    it('should reject path traversal in projectRoot', async () => {
+      await expect(listSkillsTool.handler({ projectRoot: '../../../tmp' }))
+        .rejects.toThrow('path traversal');
+    });
+
+    it('should reject absolute paths outside allowed dirs', async () => {
+      await expect(listSkillsTool.handler({ projectRoot: '/tmp/evil' }))
+        .rejects.toThrow('outside allowed directories');
+    });
+  });
+});

--- a/src/hooks/learner/constants.ts
+++ b/src/hooks/learner/constants.ts
@@ -12,7 +12,10 @@ export const USER_SKILLS_DIR = join(homedir(), '.claude', 'skills', 'omc-learned
 export const GLOBAL_SKILLS_DIR = join(homedir(), '.omc', 'skills');
 
 /** Project-level skills subdirectory */
-export const PROJECT_SKILLS_SUBDIR = '.omc/skills';
+export const PROJECT_SKILLS_SUBDIR = join('.omc', 'skills');
+
+/** Maximum recursion depth for skill file discovery */
+export const MAX_RECURSION_DEPTH = 10;
 
 /** Valid skill file extension */
 export const SKILL_EXTENSION = '.md';

--- a/src/hooks/learner/loader.ts
+++ b/src/hooks/learner/loader.ts
@@ -6,8 +6,8 @@
 
 import { readFileSync } from 'fs';
 import { createHash } from 'crypto';
-import { relative } from 'path';
-import { findSkillFiles, getSkillsDir } from './finder.js';
+import { relative, normalize } from 'path';
+import { findSkillFiles } from './finder.js';
 import { parseSkillFile } from './parser.js';
 import { DEBUG_ENABLED } from './constants.js';
 import type { LearnedSkill, SkillMetadata } from './types.js';
@@ -40,8 +40,7 @@ export function loadAllSkills(projectRoot: string | null): LearnedSkill[] {
       }
 
       const skillId = metadata.id!;
-      const skillsDir = getSkillsDir(candidate.scope, projectRoot || undefined);
-      const relativePath = relative(skillsDir, candidate.path);
+      const relativePath = normalize(relative(candidate.sourceDir, candidate.path));
 
       const skill: LearnedSkill = {
         path: candidate.path,

--- a/src/hooks/learner/parser.ts
+++ b/src/hooks/learner/parser.ts
@@ -36,14 +36,25 @@ export function parseSkillFile(rawContent: string): SkillParseResult {
   try {
     const metadata = parseYamlMetadata(yamlContent);
 
-    // Validate required fields
-    if (!metadata.id) errors.push('Missing required field: id');
+    // Derive id from name if missing
+    if (!metadata.id && metadata.name) {
+      metadata.id = metadata.name
+        .toLowerCase()
+        .replace(/\s+/g, '-')
+        .replace(/[^a-z0-9-]/g, '');
+    }
+
+    // Default source to 'manual' if missing
+    if (!metadata.source) {
+      metadata.source = 'manual';
+    }
+
+    // Validate required fields (only truly required ones)
     if (!metadata.name) errors.push('Missing required field: name');
     if (!metadata.description) errors.push('Missing required field: description');
     if (!metadata.triggers || metadata.triggers.length === 0) {
       errors.push('Missing required field: triggers');
     }
-    if (!metadata.source) errors.push('Missing required field: source');
 
     return {
       metadata,

--- a/src/hooks/learner/types.ts
+++ b/src/hooks/learner/types.ts
@@ -39,7 +39,7 @@ export interface LearnedSkill {
   path: string;
   /** Path relative to skills directory */
   relativePath: string;
-  /** Whether from user (~/.claude) or project (.omc) */
+  /** Whether from user directories (~/.omc/skills or ~/.claude/skills/omc-learned) or project (.omc/skills) */
   scope: 'user' | 'project';
   /** Parsed frontmatter metadata */
   metadata: SkillMetadata;
@@ -61,6 +61,8 @@ export interface SkillFileCandidate {
   realPath: string;
   /** Scope: user or project */
   scope: 'user' | 'project';
+  /** The root directory this skill was found in (for accurate relative path computation) */
+  sourceDir: string;
 }
 
 /**

--- a/src/mcp/omc-tools-server.ts
+++ b/src/mcp/omc-tools-server.ts
@@ -1,7 +1,7 @@
 /**
  * OMC Tools Server - In-process MCP server for custom tools
  *
- * Exposes 15 custom tools (12 LSP, 2 AST, 1 python_repl) via the Claude Agent SDK's
+ * Exposes 18 custom tools (12 LSP, 2 AST, 1 python_repl, 3 skills) via the Claude Agent SDK's
  * createSdkMcpServer helper for use by subagents.
  */
 
@@ -9,6 +9,7 @@ import { createSdkMcpServer, tool } from "@anthropic-ai/claude-agent-sdk";
 import { lspTools } from "../tools/lsp-tools.js";
 import { astTools } from "../tools/ast-tools.js";
 import { pythonReplTool } from "../tools/python-repl/index.js";
+import { skillsTools } from "../tools/skills-tools.js";
 
 // Type for our tool definitions
 interface ToolDef {
@@ -22,7 +23,8 @@ interface ToolDef {
 const allTools: ToolDef[] = [
   ...(lspTools as unknown as ToolDef[]),
   ...(astTools as unknown as ToolDef[]),
-  pythonReplTool as unknown as ToolDef
+  pythonReplTool as unknown as ToolDef,
+  ...(skillsTools as unknown as ToolDef[])
 ];
 
 // Convert to SDK tool format
@@ -59,13 +61,15 @@ export function getOmcToolNames(options?: {
   includeLsp?: boolean;
   includeAst?: boolean;
   includePython?: boolean;
+  includeSkills?: boolean;
 }): string[] {
-  const { includeLsp = true, includeAst = true, includePython = true } = options || {};
+  const { includeLsp = true, includeAst = true, includePython = true, includeSkills = true } = options || {};
 
   return omcToolNames.filter(name => {
     if (!includeLsp && name.includes('lsp_')) return false;
     if (!includeAst && name.includes('ast_')) return false;
     if (!includePython && name.includes('python_repl')) return false;
+    if (!includeSkills && (name.includes('load_omc_skills') || name.includes('list_omc_skills'))) return false;
     return true;
   });
 }

--- a/src/tools/skills-tools.ts
+++ b/src/tools/skills-tools.ts
@@ -1,0 +1,174 @@
+/**
+ * Skills Tools
+ *
+ * MCP tools for loading and listing OMC learned skills
+ * from local (.omc/skills/) and global (~/.omc/skills/) directories.
+ */
+
+import { z } from 'zod';
+import { resolve, normalize, sep } from 'path';
+import { homedir } from 'os';
+import { loadAllSkills } from '../hooks/learner/loader.js';
+import { MAX_SKILL_CONTENT_LENGTH } from '../hooks/learner/constants.js';
+import type { LearnedSkill } from '../hooks/learner/types.js';
+
+/** Allowed boundary directories for projectRoot validation */
+const ALLOWED_BOUNDARIES = [process.cwd(), homedir()];
+
+/** Role boundary tags that could be used for prompt injection */
+const ROLE_BOUNDARY_PATTERN = /^<\s*\/?\s*(system|human|assistant|user|tool_use|tool_result)\b[^>]*>/i;
+
+/**
+ * Validate projectRoot is within allowed directories.
+ * Prevents path traversal attacks.
+ */
+function validateProjectRoot(input: string): string {
+  const normalized = normalize(resolve(input));
+  // Reject path traversal sequences in raw input
+  if (input.includes('..')) {
+    throw new Error('Invalid project root: path traversal not allowed');
+  }
+  // Positive boundary validation: resolved path must be under cwd or HOME
+  const isWithinAllowed = ALLOWED_BOUNDARIES.some(boundary => {
+    const normalizedBoundary = normalize(boundary);
+    return normalized === normalizedBoundary ||
+           normalized.startsWith(normalizedBoundary + sep);
+  });
+  if (!isWithinAllowed) {
+    throw new Error('Invalid project root: path is outside allowed directories');
+  }
+  return normalized;
+}
+
+/**
+ * Sanitize skill content to prevent prompt injection.
+ */
+function sanitizeSkillContent(content: string): string {
+  // Truncate to max length
+  const truncated = content.length > MAX_SKILL_CONTENT_LENGTH
+    ? content.slice(0, MAX_SKILL_CONTENT_LENGTH) + '\n[truncated]'
+    : content;
+  // Strip role boundary tags
+  return truncated
+    .split('\n')
+    .filter(line => !ROLE_BOUNDARY_PATTERN.test(line.trim()))
+    .join('\n');
+}
+
+// Schema definitions
+const loadLocalSchema = {
+  projectRoot: z.string()
+    .max(500)
+    .optional()
+    .describe('Project root directory (defaults to cwd)'),
+};
+
+// Empty ZodRawShape: SDK expects plain object of z-types; {} means no parameters
+const loadGlobalSchema = {};
+
+const listSkillsSchema = {
+  projectRoot: z.string()
+    .max(500)
+    .optional()
+    .describe('Project root directory (defaults to cwd)'),
+};
+
+/**
+ * Format skills into readable markdown output.
+ */
+function formatSkillOutput(skills: LearnedSkill[]): string {
+  if (skills.length === 0) {
+    return 'No skills found in the searched directories.';
+  }
+
+  const lines: string[] = [];
+
+  for (const skill of skills) {
+    lines.push(`### ${skill.metadata.id}`);
+    lines.push(`- **Name:** ${skill.metadata.name}`);
+    lines.push(`- **Description:** ${skill.metadata.description}`);
+    lines.push(`- **Triggers:** ${skill.metadata.triggers.join(', ')}`);
+    if (skill.metadata.tags?.length) {
+      lines.push(`- **Tags:** ${skill.metadata.tags.join(', ')}`);
+    }
+    lines.push(`- **Scope:** ${skill.scope}`);
+    lines.push(`- **Path:** ${skill.relativePath}`);
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+// Tool 1: load_omc_skills_local
+export const loadLocalTool = {
+  name: 'load_omc_skills_local',
+  description: 'Load and list skills from the project-local .omc/skills/ directory. Returns skill metadata (id, name, description, triggers, tags) for all discovered project-scoped skills.',
+  schema: loadLocalSchema,
+  handler: async (args: { projectRoot?: string }) => {
+    const projectRoot = args.projectRoot ? validateProjectRoot(args.projectRoot) : process.cwd();
+    const allSkills = loadAllSkills(projectRoot);
+    const projectSkills = allSkills.filter(s => s.scope === 'project');
+
+    return {
+      content: [{
+        type: 'text' as const,
+        text: `## Project Skills (${projectSkills.length})\n\n${formatSkillOutput(projectSkills)}`,
+      }],
+    };
+  },
+};
+
+// Tool 2: load_omc_skills_global
+export const loadGlobalTool = {
+  name: 'load_omc_skills_global',
+  description: 'Load and list skills from global user directories (~/.omc/skills/ and ~/.claude/skills/omc-learned/). Returns skill metadata for all discovered user-scoped skills.',
+  schema: loadGlobalSchema,
+  handler: async (_args: Record<string, never>) => {
+    const allSkills = loadAllSkills(null);
+    const userSkills = allSkills.filter(s => s.scope === 'user');
+
+    return {
+      content: [{
+        type: 'text' as const,
+        text: `## Global User Skills (${userSkills.length})\n\n${formatSkillOutput(userSkills)}`,
+      }],
+    };
+  },
+};
+
+// Tool 3: list_omc_skills
+export const listSkillsTool = {
+  name: 'list_omc_skills',
+  description: 'List all available skills (both project-local and global user skills). Project skills take priority over user skills with the same ID.',
+  schema: listSkillsSchema,
+  handler: async (args: { projectRoot?: string }) => {
+    const projectRoot = args.projectRoot ? validateProjectRoot(args.projectRoot) : process.cwd();
+    const skills = loadAllSkills(projectRoot);
+    const projectSkills = skills.filter(s => s.scope === 'project');
+    const userSkills = skills.filter(s => s.scope === 'user');
+
+    let output = `## All Available Skills (${skills.length} total)\n\n`;
+
+    if (projectSkills.length > 0) {
+      output += `### Project Skills (${projectSkills.length})\n\n${formatSkillOutput(projectSkills)}\n`;
+    }
+
+    if (userSkills.length > 0) {
+      output += `### User Skills (${userSkills.length})\n\n${formatSkillOutput(userSkills)}`;
+    }
+
+    if (skills.length === 0) {
+      output = '## No Skills Found\n\nNo skill files were discovered in any searched directories.\n\nSearched:\n- Project: .omc/skills/\n- Global: ~/.omc/skills/\n- Legacy: ~/.claude/skills/omc-learned/';
+    }
+
+    return {
+      content: [{
+        type: 'text' as const,
+        text: output,
+      }],
+    };
+  },
+};
+
+/** All skills tools for registration in omc-tools-server */
+export const skillsTools = [loadLocalTool, loadGlobalTool, listSkillsTool];


### PR DESCRIPTION
## Summary

Verification of upstream PR #227 (fix: backward-compatible skill parser for legacy files).

### Changes from PR #227
- Derive `id` from `name` when missing (lowercase, spaces→hyphens, strip non-alphanumeric)
- Default `source` to `'manual'` when missing  
- Only validate truly required fields: `name`, `description`, `triggers`

### Verification Results

#### Automated Tests
- ✅ `npx tsc --noEmit` passes
- ✅ All 13 new backward-compatibility parser tests pass
- ✅ Existing mnemosyne parser tests pass (with expectation update)
- ⚠️ Some bridge.test.ts failures exist, but these are pre-existing issues from PR #225 (unrelated to this PR)

#### Manual Tests
- ✅ Legacy skill file (no id/source) parses successfully
- ✅ `id` derived correctly from `name` field:
  - "API/REST Helper!" → "apirest-helper"
  - "My   Super   Skill" → "my-super-skill"  
  - "Simple Name" → "simple-name"
- ✅ `source` defaults to `'manual'`
- ✅ `loadAllSkills()` returns legacy skills with derived metadata
- ✅ Skills with explicit id/source preserve those values

### Files Changed
1. `src/hooks/learner/parser.ts` - Main fix (+14/-3 lines)
2. `src/__tests__/hooks/learner/parser.test.ts` - New test file (+240 lines)
3. `src/__tests__/mnemosyne/parser.test.ts` - Test expectation update (+1/-1 lines)

---

🤖 Generated with [Claude Code](https://claude.ai/code)